### PR TITLE
fix(mock): Do not handle header if none configured

### DIFF
--- a/src/main/java/io/gravitee/policy/mock/MockPolicy.java
+++ b/src/main/java/io/gravitee/policy/mock/MockPolicy.java
@@ -121,10 +121,12 @@ public class MockPolicy {
         }
 
         private void init() {
-            mockPolicyConfiguration.getHeaders()
-                    .stream()
-                    .filter(header -> header.getName() != null && !header.getName().trim().isEmpty())
-                    .forEach(header -> headers.add(header.getName(), header.getValue()));
+            if (mockPolicyConfiguration.getHeaders() != null) {
+                mockPolicyConfiguration.getHeaders()
+                        .stream()
+                        .filter(header -> header.getName() != null && !header.getName().trim().isEmpty())
+                        .forEach(header -> headers.add(header.getName(), header.getValue()));
+            }
         }
 
         @Override


### PR DESCRIPTION
Closes gravitee-io/issues#172