### PR TITLE
fix(mock): Headers are not required when preparing the mock response

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -141,7 +141,6 @@
       }
     }
   },"required": [
-      "status",
-      "headers"
+      "status"
   ]
 }


### PR DESCRIPTION
Closes gravitee-io/issues#573