### PR TITLE
fix: handle no components in OpenAPI descriptor

### DIFF
--- a/src/main/java/io/gravitee/policy/mock/swagger/MockOAIOperationVisitor.java
+++ b/src/main/java/io/gravitee/policy/mock/swagger/MockOAIOperationVisitor.java
@@ -142,6 +142,9 @@ public class MockOAIOperationVisitor implements OAIOperationVisitor {
     }
 
     private boolean isRefArray(OpenAPI oai, final String ref) {
+        if (oai.getComponents() == null) {
+            return false;
+        }
         final String simpleRef = ref.substring(ref.lastIndexOf('/') + 1);
         final Schema schema = oai.getComponents().getSchemas().get(simpleRef);
         return schema instanceof ArraySchema;
@@ -169,7 +172,7 @@ public class MockOAIOperationVisitor implements OAIOperationVisitor {
     }
 
     private Object getResponseFromSimpleRef(OpenAPI oai, String ref) {
-        if (ref == null) {
+        if (ref == null || oai.getComponents() == null) {
             return null;
         }
         final String simpleRef = ref.substring(ref.lastIndexOf('/') + 1);
@@ -181,7 +184,11 @@ public class MockOAIOperationVisitor implements OAIOperationVisitor {
         if (properties == null) {
             return null;
         }
-        return properties.entrySet().stream().collect(toMap(Map.Entry::getKey, e -> this.getSchemaValue(oai, e.getValue())));
+        return properties
+            .entrySet()
+            .stream()
+            .filter(e -> this.getSchemaValue(oai, e.getValue()) != null)
+            .collect(toMap(Map.Entry::getKey, e -> this.getSchemaValue(oai, e.getValue())));
     }
 
     private Object getSchemaValue(final OpenAPI oai, Schema schema) {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2732

**Description**

In some case, when the OpenAPI descriptor in malformed or can't be fully parsed, the `components` section is empty. And so we can't find the schemas to build the mock.

This PR allows to not throw an exception when it's happening and just return an empty value.