### PR TITLE
fix: handle array in response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
-        <swagger-parser.version>2.0.14</swagger-parser.version>
+        <swagger-parser.version>2.1.11</swagger-parser.version>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
@@ -124,6 +124,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/gravitee/policy/mock/swagger/MockOAIOperationVisitor.java
+++ b/src/main/java/io/gravitee/policy/mock/swagger/MockOAIOperationVisitor.java
@@ -122,8 +122,8 @@ public class MockOAIOperationVisitor implements OAIOperationVisitor {
     }
 
     private void processResponseSchema(OpenAPI oai, Configuration configuration, String type, Schema responseSchema) {
+        configuration.setArray("array".equals(type));
         if (responseSchema.getProperties() == null) {
-            configuration.setArray("array".equals(type));
             if (responseSchema.getAdditionalProperties() != null) {
                 configuration.setResponse(
                     Collections.singletonMap("additionalProperty", ((Schema) responseSchema.getAdditionalProperties()).getType())

--- a/src/test/java/MockOAIOperationVisitorTest.java
+++ b/src/test/java/MockOAIOperationVisitorTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.gravitee.policy.api.swagger.Policy;
+import io.gravitee.policy.mock.configuration.MockPolicyConfiguration;
+import io.gravitee.policy.mock.swagger.MockOAIOperationVisitor;
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import java.io.IOException;
+import java.util.Optional;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class MockOAIOperationVisitorTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    {
+        mapper.configure(JsonGenerator.Feature.WRITE_NUMBERS_AS_STRINGS, true);
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+    }
+
+    private final MockOAIOperationVisitor cut = new MockOAIOperationVisitor();
+
+    @ParameterizedTest
+    @CsvSource(
+        value = {
+            "openapi/array-response.json, /resources, openapi/array-response-expected.json",
+            "openapi/simple-response.json, /resource, openapi/simple-response-expected.json",
+        }
+    )
+    public void shouldGenerateMock(String pathToOpenAPI, String resourceName, String pathToExpectedConfiguration) throws IOException {
+        ParseOptions options = new ParseOptions();
+        options.setResolveFully(true);
+
+        OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/" + pathToOpenAPI, null, options).getOpenAPI();
+
+        Operation getResourceOperation = openAPI.getPaths().get(resourceName).getGet();
+
+        Optional<Policy> mockPolicy = cut.visit(openAPI, getResourceOperation);
+
+        assertThat(mockPolicy).isPresent();
+        Policy mockPolicyValue = mockPolicy.get();
+
+        MockPolicyConfiguration expectedConfiguration = mapper.readValue(
+            this.getClass().getResourceAsStream(pathToExpectedConfiguration),
+            MockPolicyConfiguration.class
+        );
+        assertThat(mockPolicyValue.getConfiguration()).isEqualTo(mapper.writeValueAsString(expectedConfiguration));
+    }
+}

--- a/src/test/resources/openapi/array-response-expected.json
+++ b/src/test/resources/openapi/array-response-expected.json
@@ -1,0 +1,8 @@
+{
+    "status" : "200",
+    "headers" : [ {
+        "name" : "Content-Type",
+        "value" : "application/json"
+    } ],
+    "content" : "[ {\n  \"attribute1\" : {\n    \"attribute2\" : \"Mocked string\"\n  }\n} ]"
+}

--- a/src/test/resources/openapi/array-response.json
+++ b/src/test/resources/openapi/array-response.json
@@ -1,0 +1,50 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "description": "",
+        "title": "API test",
+        "version": "1.0.0"
+    },
+    "tags": [],
+    "paths": {
+        "/resources": {
+            "get": {
+                "summary": "Get all instances of Resource",
+                "tags": ["Resource"],
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Resource"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Resource": {
+                "type": "object",
+                "properties": {
+                    "attribute1": {
+                        "type": "object",
+                        "properties": {
+                            "attribute2": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/openapi/simple-response-expected.json
+++ b/src/test/resources/openapi/simple-response-expected.json
@@ -1,0 +1,8 @@
+{
+    "status" : "200",
+    "headers" : [ {
+        "name" : "Content-Type",
+        "value" : "application/json"
+    } ],
+    "content" : "{\n  \"attribute1\" : {\n    \"attribute2\" : \"Mocked string\"\n  }\n}"
+}

--- a/src/test/resources/openapi/simple-response.json
+++ b/src/test/resources/openapi/simple-response.json
@@ -1,0 +1,47 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "description": "",
+        "title": "API test",
+        "version": "1.0.0"
+    },
+    "tags": [],
+    "paths": {
+        "/resource": {
+            "get": {
+                "summary": "Get the Resource",
+                "tags": ["Resource"],
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Resource"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Resource": {
+                "type": "object",
+                "properties": {
+                    "attribute1": {
+                        "type": "object",
+                        "properties": {
+                            "attribute2": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-869

**Description**

Fix mock policy to handle the case when the response is an array
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.13.4-apim-869-mock-array-response-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-mock/1.13.4-apim-869-mock-array-response-SNAPSHOT/gravitee-policy-mock-1.13.4-apim-869-mock-array-response-SNAPSHOT.zip)
  <!-- Version placeholder end -->
