### PR TITLE
fix: jsonSchema - config code editor mode for new policy studio display

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -140,6 +140,7 @@
       "title": "Response body",
       "description": "The payload of the mocked response (support EL)",
       "type" : "string",
+      "format": "gio-code-editor",
       "x-schema-form": {
         "type": "codemirror",
         "codemirrorOptions": {


### PR DESCRIPTION
**Issue**

n/a

**Description**

![image](https://github.com/gravitee-io/gravitee-policy-mock/assets/4974420/6a6eccae-69a5-498f-8e1c-079e5a677fa0)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.13.5-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-mock/1.13.5-json-schema-SNAPSHOT/gravitee-policy-mock-1.13.5-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
