### PR TITLE
chore(deps): upgrade all gravitee dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,25 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ],
-  "prConcurrentLimit": 3,
+  "extends": ["config:base"],
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "ci"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "chore"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["major"],
+      "semanticCommitType": "chore"
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,15 +30,15 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.2</version>
+        <version>21.0.1</version>
     </parent>
 
     <properties>
-        <gravitee-apim-gateway-tests-sdk.version>3.18.0</gravitee-apim-gateway-tests-sdk.version>
-        <gravitee-bom.version>2.5</gravitee-bom.version>
-        <gravitee-common.version>1.26.1</gravitee-common.version>
-        <gravitee-expression-language.version>1.9.2</gravitee-expression-language.version>
-        <gravitee-gateway-api.version>1.35.0</gravitee-gateway-api.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.20.29</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-bom.version>3.0.24</gravitee-bom.version>
+        <gravitee-common.version>2.3.0</gravitee-common.version>
+        <gravitee-expression-language.version>2.0.1</gravitee-expression-language.version>
+        <gravitee-gateway-api.version>2.0.3</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>


### PR DESCRIPTION
**Description**

Upgrade all Gravitee dependencies using the version defined in the latest 3.20.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.13.5`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-mock/1.13.5/gravitee-policy-mock-1.13.5.zip)
  <!-- Version placeholder end -->
