### PR TITLE
fix: rework response example extractor from schema

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.6.2
+    gravitee: gravitee-io/gravitee@4.12.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <gravitee-apim.version>4.1.24</gravitee-apim.version>
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
-        <swagger-parser.version>2.1.22</swagger-parser.version>
+        <swagger-parser.version>2.1.25</swagger-parser.version>
 
         <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->

--- a/src/test/java/io/gravitee/policy/mock/v3/MockOAIOperationVisitorTest.java
+++ b/src/test/java/io/gravitee/policy/mock/v3/MockOAIOperationVisitorTest.java
@@ -48,11 +48,13 @@ public class MockOAIOperationVisitorTest {
         value = {
             "openapi/array-response.json, /resources, openapi/array-response-expected.json",
             "openapi/simple-response.json, /resource, openapi/simple-response-expected.json",
+            "openapi/complex-response-v3.1.0.json, /resource, openapi/complex-response-v3.1.0-expected.json",
+            "openapi/complex-response-v3.0.0.json, /resource, openapi/complex-response-v3.0.0-expected.json",
         }
     )
     public void shouldGenerateMock(String pathToOpenAPI, String resourceName, String pathToExpectedConfiguration) throws IOException {
         ParseOptions options = new ParseOptions();
-        options.setResolveFully(true);
+        options.setResolveFully(false);
 
         OpenAPI openAPI = new OpenAPIParser().readLocation("src/test/resources/" + pathToOpenAPI, null, options).getOpenAPI();
 

--- a/src/test/resources/openapi/complex-response-v3.0.0-expected.json
+++ b/src/test/resources/openapi/complex-response-v3.0.0-expected.json
@@ -1,0 +1,10 @@
+{
+    "status": "200",
+    "headers": [
+        {
+            "name": "Content-Type",
+            "value": "application/json"
+        }
+    ],
+    "content": "{\n  \"result\" : [ {\n    \"bank_account_name\" : \"Mocked string\",\n    \"account_number\" : \"Mocked string\",\n    \"joint_client_guid\" : \"cli_22Gs87325ASdf798734\",\n    \"bank_institution\" : \"NBC\",\n    \"document\" : {\n      \"name\" : \"Document Name\",\n      \"guid\" : \"doc_22Gs87325ASdf798734\",\n      \"additionalProperty\" : \"Mocked string\",\n      \"code45\" : \"Mocked string\",\n      \"code46\" : \"Mocked string\"\n    },\n    \"is_joint_account\" : true,\n    \"transit_number\" : \"Mocked string\",\n    \"guid\" : \"Mocked string\",\n    \"currency\" : \"CAD\",\n    \"array_of_strings\" : [ \"string1\", \"string2\" ]\n  } ],\n  \"additionalProperty\" : \"Mocked string\",\n  \"message\" : \"Operation was a success\",\n  \"status\" : \"Success\"\n}"
+}

--- a/src/test/resources/openapi/complex-response-v3.0.0.json
+++ b/src/test/resources/openapi/complex-response-v3.0.0.json
@@ -1,0 +1,143 @@
+{
+    "openapi": "3.0.0",
+    "paths": {
+        "/resource": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response_list"
+                                }
+                            }
+                        },
+                        "description": "test"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "response_list": {
+                "additionalProperties": true,
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "example": "Success"
+                    },
+                    "message": {
+                        "type": "string",
+                        "example": "Operation was a success"
+                    },
+                    "result": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/result_list"
+                        }
+                    }
+                },
+                "required": ["message", "result", "status"]
+            },
+            "result_list": {
+                "type": "object",
+                "properties": {
+                    "bank_institution": {
+                        "type": "string",
+                        "description": "This field contains the name of the bank",
+                        "example": "NBC"
+                    },
+                    "currency": {
+                        "$ref": "#/components/schemas/currency_enum"
+                    },
+                    "is_joint_account": {
+                        "type": "boolean",
+                        "description": "Specifies whether or not this bank account has a joint owner.",
+                        "example": true
+                    },
+                    "joint_client_guid": {
+                        "type": "string",
+                        "description": "Contains the guid of the co-owner if this bank account is joint.",
+                        "example": "cli_22Gs87325ASdf798734"
+                    },
+                    "bank_account_name": {
+                        "type": "string"
+                    },
+                    "transit_number": {
+                        "type": "string"
+                    },
+                    "account_number": {
+                        "type": "string"
+                    },
+                    "guid": {
+                        "type": "string"
+                    },
+                    "document": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/bank_account_document"
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "code45": {
+                                        "type": "string"
+                                    },
+                                    "code46": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "array_of_strings": {
+                        "$ref": "#/components/schemas/array_of_strings"
+                    }
+                },
+                "required": [
+                    "account_number",
+                    "bank_account_name",
+                    "bank_institution",
+                    "currency",
+                    "document",
+                    "guid",
+                    "is_joint_account",
+                    "joint_client_guid",
+                    "transit_number"
+                ]
+            },
+            "currency_enum": {
+                "enum": ["CAD", "USD"],
+                "type": "string",
+                "description": "Represents the currency for the current entity.",
+                "example": "CAD"
+            },
+            "bank_account_document": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string"
+                },
+                "properties": {
+                    "guid": {
+                        "type": "string",
+                        "example": "doc_22Gs87325ASdf798734"
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Document Name"
+                    }
+                },
+                "required": ["guid", "name"]
+            },
+            "array_of_strings": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "example": ["string1", "string2"]
+            }
+        }
+    }
+}

--- a/src/test/resources/openapi/complex-response-v3.1.0-expected.json
+++ b/src/test/resources/openapi/complex-response-v3.1.0-expected.json
@@ -1,0 +1,10 @@
+{
+    "status": "200",
+    "headers": [
+        {
+            "name": "Content-Type",
+            "value": "application/json"
+        }
+    ],
+    "content": "{\n  \"result\" : [ {\n    \"bank_account_name\" : \"Mocked string\",\n    \"account_number\" : \"Mocked string\",\n    \"joint_client_guid\" : \"cli_22Gs87325ASdf798734\",\n    \"bank_institution\" : \"NBC\",\n    \"document\" : {\n      \"name\" : \"Document Name\",\n      \"guid\" : \"doc_22Gs87325ASdf798734\",\n      \"additionalProperty\" : \"Mocked string\",\n      \"code45\" : \"Mocked string\",\n      \"privateJoke\" : \"Mocked string\",\n      \"code46\" : \"Mocked string\"\n    },\n    \"is_joint_account\" : true,\n    \"transit_number\" : \"Mocked string\",\n    \"guid\" : \"Mocked string\",\n    \"currency\" : \"CAD\"\n  } ],\n  \"additionalProperty\" : \"Mocked string\",\n  \"message\" : \"Operation was a success\",\n  \"status\" : \"Success\"\n}"
+}

--- a/src/test/resources/openapi/complex-response-v3.1.0.json
+++ b/src/test/resources/openapi/complex-response-v3.1.0.json
@@ -1,0 +1,138 @@
+{
+    "openapi": "3.1.0",
+    "paths": {
+        "/resource": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/response_list"
+                                }
+                            }
+                        },
+                        "description": "test"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "response_list": {
+                "additionalProperties": true,
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "examples": ["Success"]
+                    },
+                    "message": {
+                        "type": "string",
+                        "examples": ["Operation was a success"]
+                    },
+                    "result": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/result_list"
+                        }
+                    }
+                },
+                "required": ["message", "result", "status"]
+            },
+            "result_list": {
+                "type": "object",
+                "properties": {
+                    "bank_institution": {
+                        "type": "string",
+                        "description": "This field contains the name of the bank",
+                        "examples": ["NBC"]
+                    },
+                    "currency": {
+                        "$ref": "#/components/schemas/currency_enum"
+                    },
+                    "is_joint_account": {
+                        "type": "boolean",
+                        "description": "Specifies whether or not this bank account has a joint owner.",
+                        "examples": [true]
+                    },
+                    "joint_client_guid": {
+                        "type": "string",
+                        "description": "Contains the guid of the co-owner if this bank account is joint.",
+                        "examples": ["cli_22Gs87325ASdf798734"]
+                    },
+                    "bank_account_name": {
+                        "type": "string"
+                    },
+                    "transit_number": {
+                        "type": "string"
+                    },
+                    "account_number": {
+                        "type": "string"
+                    },
+                    "guid": {
+                        "type": "string"
+                    },
+                    "document": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/bank_account_document",
+                                "properties": {
+                                    "privateJoke": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "code45": {
+                                        "type": "string"
+                                    },
+                                    "code46": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                "required": [
+                    "account_number",
+                    "bank_account_name",
+                    "bank_institution",
+                    "currency",
+                    "document",
+                    "guid",
+                    "is_joint_account",
+                    "joint_client_guid",
+                    "transit_number"
+                ]
+            },
+            "currency_enum": {
+                "enum": ["CAD", "USD"],
+                "type": "string",
+                "description": "Represents the currency for the current entity.",
+                "examples": ["CAD"]
+            },
+            "bank_account_document": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string"
+                },
+                "properties": {
+                    "guid": {
+                        "type": "string",
+                        "examples": ["doc_22Gs87325ASdf798734"]
+                    },
+                    "name": {
+                        "type": "string",
+                        "examples": ["Document Name"]
+                    }
+                },
+                "required": ["guid", "name"]
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-8995


**Description**

Rework code to initialize mock policy content from openAPI spec 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.14.1-refactor-openapi-mock-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-mock/1.14.1-refactor-openapi-mock-SNAPSHOT/gravitee-policy-mock-1.14.1-refactor-openapi-mock-SNAPSHOT.zip)
  <!-- Version placeholder end -->
