### PR TITLE
fix: ensure example values with date-time format are handled correctly

### DIFF
--- a/src/test/java/io/gravitee/policy/mock/v3/MockOAIOperationVisitorTest.java
+++ b/src/test/java/io/gravitee/policy/mock/v3/MockOAIOperationVisitorTest.java
@@ -50,6 +50,8 @@ public class MockOAIOperationVisitorTest {
             "openapi/simple-response.json, /resource, openapi/simple-response-expected.json",
             "openapi/complex-response-v3.1.0.json, /resource, openapi/complex-response-v3.1.0-expected.json",
             "openapi/complex-response-v3.0.0.json, /resource, openapi/complex-response-v3.0.0-expected.json",
+            "openapi/date-response.json, /client, openapi/date-response-expected.json",
+            "openapi/date-time-response.json, /client, openapi/date-time-response-expected.json",
         }
     )
     public void shouldGenerateMock(String pathToOpenAPI, String resourceName, String pathToExpectedConfiguration) throws IOException {

--- a/src/test/resources/openapi/date-response-expected.json
+++ b/src/test/resources/openapi/date-response-expected.json
@@ -1,0 +1,10 @@
+{
+    "status": 200,
+    "headers": [
+        {
+            "name": "Content-Type",
+            "value": "application/json"
+        }
+    ],
+    "content": "{\n  \"birth_date\" : \"1995-08-15\"\n}"
+}

--- a/src/test/resources/openapi/date-response.json
+++ b/src/test/resources/openapi/date-response.json
@@ -1,0 +1,28 @@
+{
+    "openapi": "3.0.0",
+    "paths": {
+        "/client": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Client info",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "birth_date": {
+                                            "type": "string",
+                                            "format": "date",
+                                            "example": "1995-08-15"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/openapi/date-time-response-expected.json
+++ b/src/test/resources/openapi/date-time-response-expected.json
@@ -1,0 +1,10 @@
+{
+    "status": 200,
+    "headers": [
+        {
+            "name": "Content-Type",
+            "value": "application/json"
+        }
+    ],
+    "content": "{\n  \"last_login\" : \"2023-12-01T10:15:30+01:00\"\n}"
+}

--- a/src/test/resources/openapi/date-time-response.json
+++ b/src/test/resources/openapi/date-time-response.json
@@ -1,0 +1,28 @@
+{
+    "openapi": "3.0.0",
+    "paths": {
+        "/client": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Client info",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "last_login": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "example": "2023-12-01T10:15:30+01:00"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9929

**Description**

Fixed issue where mock policy was not applied when OpenAPI spec defines a property with type 'string', format 'date-time', and a valid ISO timestamp example.
Added normalisation to parse 'date-time' and 'date' formats correctly during mock response generation.
Ensures mock policy is created as expected for compliant date-time examples.

Issue:

https://github.com/user-attachments/assets/6ce55c7e-16de-4e97-8630-54885d1a17a4

After fix:

https://github.com/user-attachments/assets/207edf9e-6398-4632-9597-9c8918ab00b7



**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.14.2-APIM-9929-fix-mock-policy-date-time-format-handling-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-mock/1.14.2-APIM-9929-fix-mock-policy-date-time-format-handling-SNAPSHOT/gravitee-policy-mock-1.14.2-APIM-9929-fix-mock-policy-date-time-format-handling-SNAPSHOT.zip)
  <!-- Version placeholder end -->
